### PR TITLE
Send images as byte[]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: csharp
-dotnet: 1.0.3
+dotnet: 2.0.3
 dist: trusty
 sudo: false
 cache:

--- a/ProxyAgent/HttpClient/HttpRequest.cs
+++ b/ProxyAgent/HttpClient/HttpRequest.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.IoTSolutions.ReverseProxy.HttpClient
         public IHttpRequest SetContent(byte[] content, string mediaType)
         {
             this.requestContent.Content = new ByteArrayContent(content);
-            this.ContentType = new MediaTypeHeaderValue(mediaType);
+            this.ContentType = mediaType == null ? this.defaultMediaType : new MediaTypeHeaderValue(mediaType);
             return this;
         }
     }

--- a/ProxyAgent/HttpClient/HttpRequest.cs
+++ b/ProxyAgent/HttpClient/HttpRequest.cs
@@ -43,6 +43,8 @@ namespace Microsoft.Azure.IoTSolutions.ReverseProxy.HttpClient
         IHttpRequest SetContent<T>(T sourceObject, Encoding encoding, string mediaType);
 
         IHttpRequest SetContent<T>(T sourceObject, Encoding encoding, MediaTypeHeaderValue mediaType);
+
+        IHttpRequest SetContent(byte[] content, string mediaType);
     }
 
     public class HttpRequest : IHttpRequest

--- a/ProxyAgent/HttpClient/HttpRequest.cs
+++ b/ProxyAgent/HttpClient/HttpRequest.cs
@@ -147,5 +147,12 @@ namespace Microsoft.Azure.IoTSolutions.ReverseProxy.HttpClient
             this.ContentType = mediaType;
             return this;
         }
+
+        public IHttpRequest SetContent(byte[] content, string mediaType)
+        {
+            this.requestContent.Content = new ByteArrayContent(content);
+            this.ContentType = new MediaTypeHeaderValue(mediaType);
+            return this;
+        }
     }
 }


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
All requests were being transformed into json, which caused issues when trying to send images. Any request with an image* content-type will be sent as a byte[]. Also fixed a typo
...

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
