### PR TITLE
Multipart form fix

### DIFF
--- a/ProxyAgent/HttpClient/HttpRequest.cs
+++ b/ProxyAgent/HttpClient/HttpRequest.cs
@@ -147,13 +147,22 @@ namespace Microsoft.Azure.IoTSolutions.ReverseProxy.HttpClient
             var content = JsonConvert.SerializeObject(sourceObject, Formatting.None);
             this.requestContent.Content = new StringContent(content, encoding, mediaType.MediaType);
             this.ContentType = mediaType;
+
             return this;
         }
 
         public IHttpRequest SetContent(byte[] content, string mediaType)
         {
+            if (mediaType != null && mediaType.StartsWith("multipart/form"))
+            {
+                this.requestContent.Headers.Add("ContentType", mediaType);
+            }
+            else
+            {
+                this.ContentType = mediaType == null ? this.defaultMediaType : new MediaTypeHeaderValue(mediaType);
+            }
+
             this.requestContent.Content = new ByteArrayContent(content);
-            this.ContentType = mediaType == null ? this.defaultMediaType : new MediaTypeHeaderValue(mediaType);
             return this;
         }
     }

--- a/ProxyAgent/HttpClient/HttpRequest.cs
+++ b/ProxyAgent/HttpClient/HttpRequest.cs
@@ -32,8 +32,6 @@ namespace Microsoft.Azure.IoTSolutions.ReverseProxy.HttpClient
 
         IHttpRequest SetContent(string content, Encoding encoding, string mediaType);
 
-        IHttpRequest SetContent(string content, Encoding encoding, MediaTypeHeaderValue mediaType);
-
         IHttpRequest SetContent(StringContent stringContent);
 
         IHttpRequest SetContent<T>(T sourceObject);
@@ -49,7 +47,7 @@ namespace Microsoft.Azure.IoTSolutions.ReverseProxy.HttpClient
 
     public class HttpRequest : IHttpRequest
     {
-        private readonly MediaTypeHeaderValue defaultMediaType = new MediaTypeHeaderValue("application/json");
+        private const string defaultMediaType = "application/json";
         private readonly Encoding defaultEncoding = new UTF8Encoding();
 
         private readonly HttpRequestMessage requestContent = new HttpRequestMessage();
@@ -100,23 +98,17 @@ namespace Microsoft.Azure.IoTSolutions.ReverseProxy.HttpClient
 
         public IHttpRequest SetContent(string content)
         {
-            return this.SetContent(content, this.defaultEncoding, this.defaultMediaType);
+            return this.SetContent(content, this.defaultEncoding, HttpRequest.defaultMediaType);
         }
 
         public IHttpRequest SetContent(string content, Encoding encoding)
         {
-            return this.SetContent(content, encoding, this.defaultMediaType);
+            return this.SetContent(content, encoding, HttpRequest.defaultMediaType);
         }
 
         public IHttpRequest SetContent(string content, Encoding encoding, string mediaType)
         {
-            return this.SetContent(content, encoding, new MediaTypeHeaderValue(mediaType));
-        }
-
-        public IHttpRequest SetContent(string content, Encoding encoding, MediaTypeHeaderValue mediaType)
-        {
-            this.requestContent.Content = new StringContent(content, encoding, mediaType.MediaType);
-            this.ContentType = mediaType;
+            this.requestContent.Headers.Add("ContentType", mediaType == null ? HttpRequest.defaultMediaType : mediaType);
             return this;
         }
 
@@ -129,12 +121,12 @@ namespace Microsoft.Azure.IoTSolutions.ReverseProxy.HttpClient
 
         public IHttpRequest SetContent<T>(T sourceObject)
         {
-            return this.SetContent(sourceObject, this.defaultEncoding, this.defaultMediaType);
+            return this.SetContent(sourceObject, this.defaultEncoding, HttpRequest.defaultMediaType);
         }
 
         public IHttpRequest SetContent<T>(T sourceObject, Encoding encoding)
         {
-            return this.SetContent(sourceObject, encoding, this.defaultMediaType);
+            return this.SetContent(sourceObject, encoding, HttpRequest.defaultMediaType);
         }
 
         public IHttpRequest SetContent<T>(T sourceObject, Encoding encoding, string mediaType)
@@ -153,15 +145,7 @@ namespace Microsoft.Azure.IoTSolutions.ReverseProxy.HttpClient
 
         public IHttpRequest SetContent(byte[] content, string mediaType)
         {
-            if (mediaType != null && mediaType.StartsWith("multipart/form-data"))
-            {
-                this.requestContent.Headers.Add("ContentType", mediaType);
-            }
-            else
-            {
-                this.ContentType = mediaType == null ? this.defaultMediaType : new MediaTypeHeaderValue(mediaType);
-            }
-
+            this.requestContent.Headers.Add("ContentType", mediaType == null ? HttpRequest.defaultMediaType : mediaType);
             this.requestContent.Content = new ByteArrayContent(content);
             return this;
         }

--- a/ProxyAgent/HttpClient/HttpRequest.cs
+++ b/ProxyAgent/HttpClient/HttpRequest.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.IoTSolutions.ReverseProxy.HttpClient
 
         public IHttpRequest SetContent(byte[] content, string mediaType)
         {
-            if (mediaType != null && mediaType.StartsWith("multipart/form"))
+            if (mediaType != null && mediaType.StartsWith("multipart/form-data"))
             {
                 this.requestContent.Headers.Add("ContentType", mediaType);
             }


### PR DESCRIPTION
…reverse proxy

# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
When sending over a request which includes a content type of multipart/form-data, it often includes a boundary which doesn't parse correctly when using MediaTypeHeaderValue and then forwards the request over as the default type of application/json.

This fix adds the content type header properly for multipart/form-data requests.

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
