### PR TITLE
Build script fixes for running test on VS2017 machine(s)

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -27,6 +27,7 @@ run_tests() {
 
     for PROJ in $PROJECTS; do
 	PROJ=${PROJ//\\/\/}
+	# Cleaning up special characters
 	PROJ=$(echo $PROJ | sed 's/[^a-zA-Z\.\/]//g')
 	echo "-- $PROJ"
 	dotnet test --configuration $CONFIGURATION $PROJ_MF

--- a/scripts/build
+++ b/scripts/build
@@ -23,13 +23,15 @@ run_tests() {
 
     cd $APP_HOME
     header "Running tests..."
-    PROJECTS=$(dotnet sln list | grep 'csproj$' | grep '\.Test')
+    PROJECTS=$(dotnet sln reverse-proxy.sln list | grep '\.Test')
+
     for PROJ in $PROJECTS; do
-        echo "-- $PROJ"
-        dotnet test --configuration $CONFIGURATION $PROJ
+		PROJ=${PROJ//\\/\/}
+		PROJ=$(echo $PROJ | sed 's/[^a-zA-Z\.\/]//g')
+		echo "-- $PROJ"
+		dotnet test --configuration $CONFIGURATION $PROJ_MF
     done
 }
-
 
 # workaround for https://github.com/dotnet/cli/issues/3995
 unset home

--- a/scripts/build
+++ b/scripts/build
@@ -26,10 +26,10 @@ run_tests() {
     PROJECTS=$(dotnet sln reverse-proxy.sln list | grep '\.Test')
 
     for PROJ in $PROJECTS; do
-		PROJ=${PROJ//\\/\/}
-		PROJ=$(echo $PROJ | sed 's/[^a-zA-Z\.\/]//g')
-		echo "-- $PROJ"
-		dotnet test --configuration $CONFIGURATION $PROJ_MF
+	PROJ=${PROJ//\\/\/}
+	PROJ=$(echo $PROJ | sed 's/[^a-zA-Z\.\/]//g')
+	echo "-- $PROJ"
+	dotnet test --configuration $CONFIGURATION $PROJ_MF
     done
 }
 

--- a/scripts/build
+++ b/scripts/build
@@ -30,7 +30,7 @@ run_tests() {
 	# Cleaning up special characters
 	PROJ=$(echo $PROJ | sed 's/[^a-zA-Z\.\/]//g')
 	echo "-- $PROJ"
-	dotnet test --configuration $CONFIGURATION $PROJ_MF
+	dotnet test --configuration $CONFIGURATION $PROJ
     done
 }
 


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [ ] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
Changes in the build script that adhere to the new syntax of the 'dotnet' cmd.
 
# Motivation for the change
With a 'dotnet' update on VS2017 machines, build scripts were failing. This required changes in the script(s). Required for reinstating the SDL phase.