### PR TITLE
Remove host from the list not to be forwarded

### DIFF
--- a/ProxyAgent/Proxy.cs
+++ b/ProxyAgent/Proxy.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Azure.IoTSolutions.ReverseProxy
                 "connection",
                 "content-length",
                 "keep-alive",
-                "host",
                 "upgrade",
                 "upgrade-insecure-requests"
             };


### PR DESCRIPTION
As https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23 described, host must be present. I faced problems with apps that expect host to be presented AND to have the URL the client requested.

# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

Testing the reverse proxy with a third party service, their service fails due a mismatch in the host (they use it to confirm encrypted messages. It turned out RP translate the original host header.

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
